### PR TITLE
Update Workflow_example_SR.R

### DIFF
--- a/Workflow_example_SR.R
+++ b/Workflow_example_SR.R
@@ -201,8 +201,8 @@ contour(V.theta1, V.theta2,
         V.SSE,levels = ceiling(seq(min(V.SSE),min(V.SSE)+sd(V.SSE),
                                    sd(V.SSE)/10)) ,
         col = hcl.colors(11,"heat") ,lwd=2,xlab="theta1", ylab="theta2")
-abline(h = V.theta2[100], lwd = 3,lty=2,col="darkgrey");
-abline(v = V.theta1[100], lwd = 3,lty=2,col="darkgrey");
+abline(h = V.theta2[101], lwd = 3,lty=2,col="darkgrey");
+abline(v = V.theta1[101], lwd = 3,lty=2,col="darkgrey");
 points(True_theta1,True_theta2,pch=4, lwd = 4,col="black")
 points(fit_minRMSE$par[1],fit_minRMSE$par[2],pch=4, lwd = 4,col="red")
 legend("bottomright", c("SSE-Contours", "theta1-fixed","theta2-fixed",
@@ -219,7 +219,7 @@ legend("topright", c("SSE for fixed theta1","True value"),lty=c(1,2),
        col = c("darkred","black"))
 
 par(fig=c(0.5,1,0.05,0.47), new=TRUE)
-plot(V.theta1,V.SSE[,111], type="l",col="darkred", lwd=2, xlab="theta1", 
+plot(V.theta1,V.SSE[,101], type="l",col="darkred", lwd=2, xlab="theta1", 
      ylab="SSE")
 abline(v = True_theta1, lwd = 3,lty=2,col="black");
 legend("topleft", c("SSE for fixed theta2","True value"),lty=c(1,2),lwd=c(2,2), 


### PR DESCRIPTION
It seems that lines 184 and 185 of "Workflow_example_SR.R" create two vectors each with 201 elements. The midpoint would be 101 and the fixed values indexed in the 201x201 should then also be `[101,]` and `[,101]` for the subplots in lines 214 and 222 respectively. Currently, the 100th element is selected as the fixed theta1 and theta 2 values for their respective vectors. In this case it would seem lines 214 and 222 should index should be `[100,]` and `[,100].` This is just my thought; I may be wrong. 